### PR TITLE
Migrate domain name netlify.com to netlify.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-netlify-identity`,
       options: {
-        url: `https://your-identity-instance-here.netlify.com/` // required!
+        url: `https://your-identity-instance-here.netlify.app/` // required!
       }
     }
   ]


### PR DESCRIPTION
I was confused because I didn't payed attention when I copy/pasted the `url` of my endpoint.

It could be nice to update the documentation to reflect the default behavior.

```
Starting April 14, 2020, sites without a custom domain are being moved from site-name.netlify.com to site-name.netlify.app . New websites will also have URLs ending with netlify.app by default. 
```

https://community.netlify.com/t/changes-coming-to-netlify-site-urls/8918